### PR TITLE
Makefile Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build build-dev sync sync-dev sync-dist
+
+PREBID_VERSION ?= $(shell cat gannett-version.txt)
+
+default: build
+
+build:
+	@echo "Building Prebid Version: $(PREBID_VERSION)"
+	@git checkout -q tags/$(PREBID_VERSION)
+	@yarn install --silent
+	@git checkout -q master -- modules.json
+	@gulp build --modules=modules.json
+	@git checkout -q master
+	@echo "Prebid built to ./build/dist/prebid.js"
+
+build-dev:
+	@echo "Building Prebid Dev Version: $(PREBID_VERSION)"
+	@git checkout -q tags/$(PREBID_VERSION)
+	@yarn install --silent
+	@git checkout -q master -- modules.json
+	@gulp build-bundle-dev --modules=modules.json
+	@git checkout -q master
+	@echo "Prebid dev built to ./build/dev/prebid.js"
+
+sync-dist: build
+	gsutil cp build/dist/prebid.js gs://ads-gci-www-gannett-cdn-com/vendor/pbjsandwich.min.js
+
+sync-dev: build-dev
+	gsutil cp build/dev/prebid.js gs://ads-gci-www-gannett-cdn-com/vendor/pbjsandwich.js
+
+sync: sync-dev sync-dist

--- a/gannett-build.md
+++ b/gannett-build.md
@@ -1,27 +1,21 @@
 # Gannett Build Instructions
 
-## Install
-```bash
-git clone https://github.com/prebid/Prebid.js.git
-cd Prebid.js
-yarn install
-```
+## Quickstart
+1. [Install `yarn`](https://yarnpkg.com/lang/en/docs/install/)
+1. Clone
+    ```bash
+    git clone https://github.com/GannettDigital/Prebid.js.git
+    cd Prebid.js
+    ```
+1. Run build command
+    ```bash
+    make build
+    ```    
+Compiled script will be built to `build/dist/prebid.js`
 
-## Checkout appropriate version
-```bash
-git checkout tags/$(<gannett-version.txt)
-```
+If you have access to the `ads-gci-www-gannett-cdn-com` Google Cloud bucket and have `gcloud` installed, you can automatically build and upload to the CDN in one step using `make sync`. This also builds and uploads a `dev` (unminified) version.
 
-## Build
-```bash
-git checkout master -- modules.json
-gulp build --modules=modules.json
-```
-
-## Publish to CDN
-```bash
-gsutil cp ./build/dist/prebid.js gs://ads-gci-www-gannett-cdn-com/vendor/pbjsandwich.min.js
-```
+Details on steps run during this process can be found below in [Build Details](#build-details).
 
 # Adding a Module
 Add module name to `modules.json`
@@ -40,3 +34,31 @@ git fetch upstream --prune
 git rebase -i upstream/master my-update-branch
 ```
 Who knows, you might not even have any merge conflicts! :crossed_fingers:
+
+# Build Details
+What happens when I run `make build`/`make sync`?
+
+1. Checkout appropriate version based on contents of [gannett-version.txt](gannett-version.txt)
+    ```bash
+    git checkout tags/$(<gannett-version.txt)
+    ```
+1. Checkout `modules.json` from `master` since it won't exist at the tag
+    ```bash
+    git checkout master -- modules.json
+    ```
+1. Run gulp build command
+    ```bash
+    gulp build --modules=modules.json
+    ```
+1. (`make-sync` only) Upload production file to CDN
+    ```bash
+    gsutil cp ./build/dist/prebid.js gs://ads-gci-www-gannett-cdn-com/vendor/pbjsandwich.min.js
+    ```
+1. (`make-sync` only) Build dev file
+    ```bash
+    gulp build-bundle-dev --modules=modules.json
+    ```
+1. (`make-sync` only) Upload dev file to CDN
+    ```bash
+    gsutil cp build/dev/prebid.js gs://ads-gci-www-gannett-cdn-com/vendor/pbjsandwich.js
+    ```


### PR DESCRIPTION
Build and upload both dev and prod versions with `make sync`.

Other options:
- `make build` builds prod to build/dist/prebid.js
- `make build-dev` builds dev to build/dev/prebid.js
- `make sync-dist` builds prod version and uploads it to CDN
- `make sync-dev` builds dev version and uploads it to CDN